### PR TITLE
Set up SBT explicitly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,13 +20,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - name: Check out repository
+      uses: actions/checkout@v4
     - name: Set up JDK 17
       uses: actions/setup-java@v4
       with:
         java-version: '17'
         distribution: 'temurin'
         cache: 'sbt'
+    - name: Set up SBT
+      uses: sbt/setup-sbt@v1
     - name: Compile and run application
       run: sbt run
     - name: Upload static files as artifact


### PR DESCRIPTION
SBT runner scripts are not included any longer on the ubuntu-latest images. This PR uses the [setup-sbt action](https://github.com/sbt/setup-sbt) to explicitly set up SBT.